### PR TITLE
Update NYTimes API & remove api key

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ Then add the bot from the app store and go wild.
 
 Instructions on how to use the bot can be found in the application module under the help tab.
 
+If you want to use the NYTimes API, you'll need to get one from developer.nytimes.com & set it in the environment with the name: nytimesApiKey. 

--- a/application/apps/ondobot/models/TickerModel.js
+++ b/application/apps/ondobot/models/TickerModel.js
@@ -54,11 +54,13 @@ module.exports = new Class({
 
 	getHeadlines : function()
 	{
+		var apiKey = process.env.nytimesApiKey;
+		
 		var options = {
-			params : {'api-key': '52eb4d28601e44528657e46ebede6809'},
+			params : {'apikey': apiKey},
 		}
 
-		return this.request('http://developer.nytimes.com/proxy/https/api.nytimes.com/svc/topstories/v2/home.json', 'GET', options)
+		return this.request('https://api.nytimes.com/svc/topstories/v2/home.json', 'GET', options)
 			.then(function(response)
 			{
 				return response;


### PR DESCRIPTION
Uses the proper NYTimes API Endpoint & pulls the key from the environment. I've deactivated the key that was included in the codebase. 